### PR TITLE
fix(ci): Update deprecated actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Format top-level Markdown and YAML files with Prettier
         uses: creyD/prettier_action@v4.3
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Format backend code with black
         uses: psf/black@stable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #10

## Description

<!--- A clear and concise description of the content of this pull request. -->

Replace deprecated Node.js 16 actions as GitHub's complete transition to Node.js 20 actions is expected for spring 2024.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/