### PR TITLE
add a flag for quicker mask generation inference (sam2) on same image + bug fixes

### DIFF
--- a/src/pixano_inference/celery.py
+++ b/src/pixano_inference/celery.py
@@ -100,7 +100,7 @@ def predict(request: dict[str, Any]) -> dict[str, Any]:
     match worker_task:
         case ImageTask.MASK_GENERATION:
             output = worker_provider.image_mask_generation(
-                request=ImageMaskGenerationRequest.model_construct(request), model=worker_model
+                request=ImageMaskGenerationRequest.model_construct(**request), model=worker_model
             )
         case MultimodalImageNLPTask.CONDITIONAL_GENERATION:
             output = worker_provider.text_image_conditional_generation(

--- a/src/pixano_inference/providers/sam2.py
+++ b/src/pixano_inference/providers/sam2.py
@@ -119,19 +119,19 @@ class Sam2Provider(ModelProvider):
         """
         request_input = request.to_input()
         image = convert_string_to_image(request_input.image)
-
-        if request_input.image_embedding is not None and request_input.high_resolution_features is not None:
-            image_embedding = vector_to_tensor(request_input.image_embedding)
-            high_resolution_features = [vector_to_tensor(v) for v in request_input.high_resolution_features]
-            model.set_image_embeddings(image, image_embedding, high_resolution_features)
-        elif request_input.image_embedding is not None or request_input.high_resolution_features is not None:
-            raise ValueError("Both image_embedding and high_resolution_features must be provided.")
+        if request_input.reset_predictor:
+            model.predictor.reset_predictor()
+            # if new predictor, we may use given embeddings
+            if request_input.image_embedding is not None and request_input.high_resolution_features is not None:
+                image_embedding = vector_to_tensor(request_input.image_embedding)
+                high_resolution_features = [vector_to_tensor(v) for v in request_input.high_resolution_features]
+                model.set_image_embeddings(image, image_embedding, high_resolution_features)
+            elif request_input.image_embedding is not None or request_input.high_resolution_features is not None:
+                raise ValueError("Both image_embedding and high_resolution_features must be provided.")
 
         model_input = request_input.model_dump(exclude=["image", "image_embedding", "high_resolution_features"])
         model_input["image"] = image
-        output = model.image_mask_generation(**model_input)
-        model.predictor.reset_predictor()
-        return output
+        return model.image_mask_generation(**model_input)
 
     def video_mask_generation(
         self,

--- a/src/pixano_inference/pydantic/tasks/image/mask_generation.py
+++ b/src/pixano_inference/pydantic/tasks/image/mask_generation.py
@@ -24,6 +24,7 @@ class ImageMaskGenerationInput(BaseModel):
         image: Image for image mask generation.
         image_embedding: Image embedding for the image mask generation.
         high_resolution_features: High resolution features for the image mask generation.
+        reset_predictor: True (default) for a new image. If False, keep current predictor if available.
         points: Points for the image mask generation. The first fimension is the number of prompts the second
             the number of points per mask and the third the coordinates of the points.
         labels: Labels for the image mask generation. The first fimension is the number of prompts, the second
@@ -39,6 +40,7 @@ class ImageMaskGenerationInput(BaseModel):
     image: str | Path
     image_embedding: NDArrayFloat | LanceVector | None = None
     high_resolution_features: list[NDArrayFloat] | list[LanceVector] | None = None
+    reset_predictor: bool = True
     points: list[list[list[int]]] | None = None
     labels: list[list[int]] | None = None
     boxes: list[list[int]] | None = None

--- a/src/pixano_inference/utils/media.py
+++ b/src/pixano_inference/utils/media.py
@@ -31,7 +31,7 @@ regex_media_base64 = r"^(data:[a-zA-Z]/[a-zA-Z]+;base64,)"
 
 def match_base64_media(string: str, media: str | None = None) -> re.Match[str] | None:
     """Match a base64 media."""
-    regex_media_base64 = rf"^(data:{media if media is not None else '[a-zA-Z]'}/[a-zA-Z]+;base64,)"
+    regex_media_base64 = rf"^(data:{media if media is not None else '[a-zA-Z]+'}/[a-zA-Z]+;base64,)"
     return re.match(regex_media_base64, string)
 
 


### PR DESCRIPTION
## Issue

- Request is incorrectly read for image mask generation

- typo in regex for base64 image

- add a boolean field "reset_predictor" for mask_generation:
    model.reset_predictor() is now called before inference (instead of after), ONLY if this flag is True (default). If False, it means we're working on same image as before so we keep previous predictor (if set).
