### PR TITLE
allow multi model instances with celery

### DIFF
--- a/src/pixano_inference/models/sam2.py
+++ b/src/pixano_inference/models/sam2.py
@@ -421,11 +421,11 @@ class Sam2Model(BaseInferenceModel):
             video: Video data as a video file or a list of frames files.
             objects_ids: IDs of the objects to generate masks for.
             frame_indexes: Indexes of the frames where the objects are located.
-            points: Points for the mask generation. The first fimension is the number of objects, the
+            points: Points for the mask generation. The first dimension is the number of objects, the
                 second the number of points for each object and the third the coordinates of the points.
-            labels: Labels for the mask generation. The first fimension is the number of objects, the second
+            labels: Labels for the mask generation. The first dimension is the number of objects, the second
                 the number of labels for each object.
-            boxes: Boxes for the mask generation. The first fimension is the number of objects, the second
+            boxes: Boxes for the mask generation. The first dimension is the number of objects, the second
                 the coordinates of the boxes.
             propagate: Whether to propagate the masks in the video.
             kwargs: Additional keyword arguments.

--- a/src/pixano_inference/routers/utils.py
+++ b/src/pixano_inference/routers/utils.py
@@ -36,7 +36,13 @@ async def execute_task_request(request: BaseRequest, task: Task, settings: Setti
         raise HTTPException(400, detail=f"Model {model_name} does not support the {task.value} task.")
 
     queue = model_queue_name(model_name)
-    celery_task: AsyncResult = predict.apply_async((model_name, jsonable_encoder(request),), queue=queue)
+    celery_task: AsyncResult = predict.apply_async(
+        (
+            model_name,
+            jsonable_encoder(request),
+        ),
+        queue=queue,
+    )
     return CeleryTask(id=celery_task.id, status=states.PENDING)
 
 

--- a/src/pixano_inference/routers/utils.py
+++ b/src/pixano_inference/routers/utils.py
@@ -36,7 +36,7 @@ async def execute_task_request(request: BaseRequest, task: Task, settings: Setti
         raise HTTPException(400, detail=f"Model {model_name} does not support the {task.value} task.")
 
     queue = model_queue_name(model_name)
-    celery_task: AsyncResult = predict.apply_async((jsonable_encoder(request),), queue=queue)
+    celery_task: AsyncResult = predict.apply_async((model_name, jsonable_encoder(request),), queue=queue)
     return CeleryTask(id=celery_task.id, status=states.PENDING)
 
 


### PR DESCRIPTION
## Issue

The Celery worker queue as it is used currently only allow one model for the Pixano Inference provider.

## Description

Use a registry to keeps multiple models