### PR TITLE
fix "cudagraph overwritten" bug

### DIFF
--- a/src/pixano_inference/__version__.py
+++ b/src/pixano_inference/__version__.py
@@ -6,4 +6,4 @@
 
 # ruff: noqa: D100
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/src/pixano_inference/celery.py
+++ b/src/pixano_inference/celery.py
@@ -147,8 +147,8 @@ def add_celery_worker_and_queue(provider: str, model_config: ModelConfig, gpu: i
     ]
     worker = Popen(
         command,
-        #stdout=subprocess.PIPE,  # comment this 2 for more logs
-        #stderr=subprocess.PIPE,
+        # stdout=subprocess.PIPE,  # comment this 2 for more logs
+        # stderr=subprocess.PIPE,
         start_new_session=True,
     )
 

--- a/src/pixano_inference/celery.py
+++ b/src/pixano_inference/celery.py
@@ -147,8 +147,8 @@ def add_celery_worker_and_queue(provider: str, model_config: ModelConfig, gpu: i
     ]
     worker = Popen(
         command,
-        stdout=subprocess.PIPE,  # comment this 2 for more logs
-        stderr=subprocess.PIPE,
+        #stdout=subprocess.PIPE,  # comment this 2 for more logs
+        #stderr=subprocess.PIPE,
         start_new_session=True,
     )
 

--- a/src/pixano_inference/models/sam2.py
+++ b/src/pixano_inference/models/sam2.py
@@ -50,6 +50,7 @@ handler.setFormatter(formatter)
 celery_logger.addHandler(handler)
 celery_logger.setLevel(logging.INFO)
 
+
 class Sam2Model(BaseInferenceModel):
     """Inference model for the SAM2 model."""
 

--- a/src/pixano_inference/models/sam2.py
+++ b/src/pixano_inference/models/sam2.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import gc
+import logging
 from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -42,6 +43,12 @@ if is_sam2_installed():
 if TYPE_CHECKING:
     from torch import Tensor
 
+celery_logger = logging.getLogger("celery")
+handler = logging.FileHandler("celery_logs.log")
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+celery_logger.addHandler(handler)
+celery_logger.setLevel(logging.INFO)
 
 class Sam2Model(BaseInferenceModel):
     """Inference model for the SAM2 model."""
@@ -433,8 +440,10 @@ class Sam2Model(BaseInferenceModel):
         Returns:
             Output of the generation.
         """
+        celery_logger.info("SAM2-0")
         # Check the input list types
         with torch.inference_mode():
+            torch.compiler.cudagraph_mark_step_begin()
             if (
                 points is not None
                 and not isinstance(points, list)

--- a/src/pixano_inference/utils/media.py
+++ b/src/pixano_inference/utils/media.py
@@ -115,6 +115,8 @@ def convert_string_video_to_bytes_or_path(str_video: str | Path) -> bytes | Path
     Returns:
         The video.
     """
+    if isinstance(str_video, list):
+        return [convert_string_video_to_bytes_or_path(str_video_elem) for str_video_elem in str_video]
     if isinstance(str_video, str):
         if is_url(str_video):
             video_bytes = requests.get(str_video, stream=True).raw


### PR DESCRIPTION
## Issue

A new bug appeared (probably some lib change?)
[2025-06-11 13:41:59,673: ERROR/MainProcess] Task pixano_inference.celery.predict[79edfdc4-e66e-4ed4-90a9-f3ae800e86d2] raised unexpected: RuntimeError('Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run. Stack trace: File "/home/brenault/next-pixano/sam2/sam2/modeling/memory_attention.py", line 166, in forward\n    normed_output = normed_output.transpose(0, 1). To prevent overwriting, clone the tensor outside of torch.compile() or call torch.compiler.cudagraph_mark_step_begin() before each model invocation.')

## Description
call torch.compiler.cudagraph_mark_step_begin() as suggested

also, put back some logs (should remove them in future PR)

also, upgrade version for immediate release
