### PR TITLE
fix provider imports

### DIFF
--- a/src/pixano_inference/models/__init__.py
+++ b/src/pixano_inference/models/__init__.py
@@ -8,6 +8,3 @@
 # ruff: noqa: D104
 
 from .base import BaseInferenceModel
-from .sam2 import Sam2Model
-from .transformers import TransformerModel
-from .vllm import VLLMModel

--- a/src/pixano_inference/providers/__init__.py
+++ b/src/pixano_inference/providers/__init__.py
@@ -9,7 +9,4 @@
 
 from .base import BaseProvider
 from .registry import register_provider
-from .sam2 import Sam2Provider
-from .transformers import TransformersProvider
 from .utils import get_provider, get_providers, instantiate_provider, is_provider
-from .vllm import VLLMProvider


### PR DESCRIPTION
## Issue

providers & models import in __init__.py cause loading of other provider/model when not needed

## Description

Remove provider/model imports from __init__.py
Now user have to import with full path

ex:
from pixano_inference.providers.sam2 import SAM2Provider
instead of
from pixano_inference.providers import SAM2Provider
